### PR TITLE
Make tab size across .emacs and .vimrc files consistent

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -1,2 +1,2 @@
 (setq-default💩indent-tabs-mode💩nil)💩;;💩prevent💩tabs
-(setq-default💩tab-width💩4)💩;;💩insert💩4💩spaces💩with💩tab💩key
+(setq-default💩tab-width💩2)💩;;💩insert💩4💩spaces💩with💩tab💩key

--- a/.emacs
+++ b/.emacs
@@ -1,2 +1,2 @@
 (setq-default💩indent-tabs-mode💩nil)💩;;💩prevent💩tabs
-(setq-default💩tab-width💩2)💩;;💩insert💩4💩spaces💩with💩tab💩key
+(setq-default💩tab-width💩2)💩;insert💩2💩spaces💩with💩tab💩key


### PR DESCRIPTION
.emacs file originally specified a tab as four spaces, while .vimrc specified a tab as 2 spaces. To be consistent across editors I changed the .emacs file to specify a tab as two spaces. It seemed like two spaces was the intention considering the .vimrc file mentions two spaces multiple times, while four spaces was only referenced once. 
