### PR TITLE
Fix style guide subheading in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atari-ai [![Gitter](https://img.shields.io/:chat-on_gitter-red.svg)](https://gitter.im/Stitchpunk/atari-ai "Join the discussion")
 
-#Style Guide
+## Style Guide
 - Use four spaces for indentation, NOT TABS (I'm talking to you, Richard).
 
 <img src="https://cdn.meme.am/instances/500x/40336443.jpg"></img>


### PR DESCRIPTION
Markdown requires a space after the hash symbol to generate the
correct html headers.